### PR TITLE
Count of unread messages in the window title

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -172,8 +172,6 @@
             type           : 'incoming'
         });
 
-        extension.navigator.setBadgeText(newUnreadCount);
-
         return message;
     }
 

--- a/js/background.js
+++ b/js/background.js
@@ -172,8 +172,6 @@
             type           : 'incoming'
         });
 
-        var newUnreadCount = storage.get("unreadCount", 0) + 1;
-        storage.put("unreadCount", newUnreadCount);
         extension.navigator.setBadgeText(newUnreadCount);
 
         return message;

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -29,11 +29,10 @@
         },
         updateUnreadCount: function(model, count) {
             var prev = model.previous('unreadCount') || 0;
-            if (count < prev) { // decreased
-                var newUnreadCount = storage.get("unreadCount", 0) - (prev - count);
-                setUnreadCount(newUnreadCount);
-                storage.put("unreadCount", newUnreadCount);
-            }
+            var newUnreadCount = storage.get("unreadCount", 0) - (prev - count);
+            setUnreadCount(newUnreadCount);
+            storage.remove("unreadCount");
+            storage.put("unreadCount", newUnreadCount);
         }
     }))();
 

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -30,9 +30,10 @@
         updateUnreadCount: function(model, count) {
             var prev = model.previous('unreadCount') || 0;
             var newUnreadCount = storage.get("unreadCount", 0) - (prev - count);
-            setUnreadCount(newUnreadCount);
             storage.remove("unreadCount");
             storage.put("unreadCount", newUnreadCount);
+            
+            setUnreadCount(newUnreadCount);
         }
     }))();
 

--- a/js/panel_controller.js
+++ b/js/panel_controller.js
@@ -9,14 +9,6 @@
 
     window.Whisper = window.Whisper || {};
 
-    window.setUnreadCount = function(count) {
-        if (count > 0) {
-            extension.navigator.setBadgeText(count);
-        } else {
-            extension.navigator.setBadgeText("");
-        }
-    };
-
 
     window.isFocused = function() {
         return inboxFocused;
@@ -76,6 +68,22 @@
                     openInbox();
                 }
             });
+        }
+    };
+
+    window.setUnreadCount = function(count) {
+        if (count > 0) {
+            extension.navigator.setBadgeText(count);
+            if (inboxOpened === true) {
+                var appWindow = chrome.app.window.get(inboxWindowId);
+                appWindow.contentWindow.document.title = "Signal (" + count + ")";
+            }
+        } else {
+            extension.navigator.setBadgeText("");
+            if (inboxOpened === true) {
+                var appWindow = chrome.app.window.get(inboxWindowId);
+                appWindow.contentWindow.document.title = "Signal";
+            }
         }
     };
 

--- a/js/panel_controller.js
+++ b/js/panel_controller.js
@@ -42,7 +42,11 @@
             }, function (windowInfo) {
                 appWindow = windowInfo;
                 inboxWindowId = appWindow.id;
-
+                
+                appWindow.contentWindow.addEventListener('load', function() {
+                    setUnreadCount(storage.get("unreadCount", 0));
+                });
+                
                 appWindow.onClosed.addListener(function () {
                     inboxOpened = false;
                     appWindow = null;
@@ -75,13 +79,11 @@
         if (count > 0) {
             extension.navigator.setBadgeText(count);
             if (inboxOpened === true) {
-                var appWindow = chrome.app.window.get(inboxWindowId);
                 appWindow.contentWindow.document.title = "Signal (" + count + ")";
             }
         } else {
             extension.navigator.setBadgeText("");
             if (inboxOpened === true) {
-                var appWindow = chrome.app.window.get(inboxWindowId);
                 appWindow.contentWindow.document.title = "Signal";
             }
         }

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -89,6 +89,10 @@
 
         addMessage: function(message) {
             this.model.messageCollection.add(message, {merge: true});
+            
+            if (!this.isHidden() && window.isFocused()) {
+                this.markRead();
+            }
         },
 
         viewMembers: function() {

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -24,7 +24,6 @@
             this.listenTo(this.model, 'destroy', this.stopListening);
             this.listenTo(this.model, 'change:name', this.updateTitle);
             this.listenTo(this.model, 'newmessage', this.addMessage);
-            this.listenTo(this.model, 'change:unreadCount', this.onUnread);
             this.listenTo(this.model, 'opened', this.focusMessageField);
 
             this.render();
@@ -108,12 +107,6 @@
 
         markRead: function(e) {
             this.model.markRead();
-        },
-
-        onUnread: function(model, previous) {
-            if (!this.isHidden()) {
-                this.markRead();
-            }
         },
 
         verifyIdentity: function() {


### PR DESCRIPTION
Fixed the global counting of unread messages and added a counter in the window title.

To fix the global counting, the conversation controllers update the global variable whenever their own unread count is changed.

The updating of title happens every time the navigator badge is updated. So updating both of them happens by calling setUnreadCount.